### PR TITLE
When stopSco(), speechRecognizer.stopListening()

### DIFF
--- a/app/src/main/java/com/example/bluetoothscoapp/MainActivity.java
+++ b/app/src/main/java/com/example/bluetoothscoapp/MainActivity.java
@@ -134,11 +134,11 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void stopSco() {
+        speechRecognizer.stopListening();
         audioManager.stopBluetoothSco();
         audioManager.setBluetoothScoOn(false);
         isScoOn = false;
         btnToggleSco.setText("Start Bluetooth SCO");
-        speechRecognizer.stopListening();
     }
 
     private void startListening() {


### PR DESCRIPTION
Add `speechRecognizer.stopListening();` call in `stopSco()` method to stop listening when SCO is stopped.

* Call `speechRecognizer.stopListening();` before `audioManager.stopBluetoothSco();` in `stopSco()` method

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alienyang/BluetoothSCOApp/pull/4?shareId=3a925c83-a4e9-4074-a5df-3545f4b8572f).